### PR TITLE
FIX Multiple middlewares and reading req.stream

### DIFF
--- a/falcon_marshmallow/_version.py
+++ b/falcon_marshmallow/_version.py
@@ -12,5 +12,5 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-__version_info__ = (0, 1, 0)
+__version_info__ = (0, 1, 1)
 __version__ = '.'.join([str(ver) for ver in __version_info__])

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ SETUP_DEPENDENCIES = [
 TEST_DEPENDENCIES = [
     'pytest',
     'pytest-cov',
+    'ipython<6;python_version<"3"',
+    'ipython;python_version>="3"',
     'ipdb',
     'mock;python_version<"3.3"',
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -144,8 +144,8 @@ class TestAllIncludedMiddleware:
     """
 
     headers = {
-        'Content-Type': 'application/json',
-        'Accepts': 'application/json'
+        'Content-Type': str('application/json'),
+        'Accepts': str('application/json')
     }
 
     def test_get(self, hydrated_client_multiple_middleware):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -446,7 +446,7 @@ class TestEmptyRequestDropper:
     def test_raise_on_empty_body(self, read):
         # type: (str) -> None
         """Test that we raise if we get an empty body"""
-        req = mock.Mock(content_length=10)
+        req = mock.Mock(content_length=10, context={})
         req.stream.read.return_value = read
 
         if not read:


### PR DESCRIPTION
Added a helper to stash the results of `req.stream.read()`
transparently (from the POV of the middleware).

It's directly available at `context[CONTENT_KEY]`, but calling
`get_stash_content(req)` does the right thing.