### PR TITLE
Switch to Bounded Stream

### DIFF
--- a/falcon_marshmallow/_version.py
+++ b/falcon_marshmallow/_version.py
@@ -12,5 +12,5 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-__version_info__ = (0, 1, 1)
+__version_info__ = (0, 2, 0)
 __version__ = '.'.join([str(ver) for ver in __version_info__])

--- a/falcon_marshmallow/middleware.py
+++ b/falcon_marshmallow/middleware.py
@@ -46,7 +46,7 @@ def get_stashed_content(req):
     """
     # This is the key which will hold the already-read content.
     if req.context.get(CONTENT_KEY) is None:
-        req.context[CONTENT_KEY] = req.stream.read()
+        req.context[CONTENT_KEY] = req.bounded_stream.read()
 
     return req.context[CONTENT_KEY]
 
@@ -257,7 +257,7 @@ class Marshmallow:
                 )
 
             try:
-                body = get_stashed_content(req).decode('utf-8')
+                body = get_stashed_content(req)
                 parsed = self._json.loads(body)
             except UnicodeDecodeError:
                 raise HTTPBadRequest('Body was not encoded as UTF-8')
@@ -277,9 +277,7 @@ class Marshmallow:
 
             body = get_stashed_content(req)
             try:
-                req.context[self._req_key] = self._json.loads(
-                    body.decode('utf-8')
-                )
+                req.context[self._req_key] = self._json.loads(body)
             except (ValueError, UnicodeDecodeError):
                 raise HTTPBadRequest(
                     description=(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -165,7 +165,7 @@ class TestAllIncludedMiddleware:
         }
         resp = hydrated_client_multiple_middleware.simulate_post(
             '/philosophers',
-            body=json.dumps(phil).encode(),
+            body=json.dumps(phil),
             headers=self.headers
         )  # type: testing.Result
         assert resp.status_code == 200
@@ -190,7 +190,7 @@ class TestMarshmallowMiddleware:
         # type: (testing.TestClient) -> None
         """Test posting a new philosopher"""
         phil = {
-            'name': 'Albert Camus',
+            'name': 'Albért Camus',
             'birth': date(1913, 11, 7).isoformat(),
             'death': date(1960, 1, 4).isoformat(),
             'schools': ['existentialism', 'absurdism'],
@@ -198,7 +198,7 @@ class TestMarshmallowMiddleware:
         }
         resp = hydrated_client.simulate_post(
             '/philosophers',
-            body=json.dumps(phil).encode()
+            body=json.dumps(phil)
         )  # type: testing.Result
         assert resp.status_code == 200
         parsed = resp.json
@@ -210,7 +210,7 @@ class TestMarshmallowMiddleware:
         assert resp.status_code == 200
         got = resp.json
         assert got['id'] == parsed['id']
-        assert got['name'] == 'Albert Camus'
+        assert got['name'] == 'Albért Camus'
         assert got['birth'] == '1913-11-07'
 
     def test_post_unprocessable_entitty(self, hydrated_client):
@@ -225,7 +225,7 @@ class TestMarshmallowMiddleware:
         }
         resp = hydrated_client.simulate_post(
             '/philosophers',
-            body=json.dumps(phil).encode()
+            body=json.dumps(phil)
         )  # type: testing.Result
         assert resp.status == status_codes.HTTP_UNPROCESSABLE_ENTITY
         parsed = resp.json


### PR DESCRIPTION
Discovered during testing of ihiji/identification#22

* Switched to Falcon's `bounded_stream` rather than
`stream` for:
  * More consistent reads
  * Better and much easier unicode handling