### PR TITLE
Marshmallow 3.x compatibility

### DIFF
--- a/falcon_marshmallow/_version.py
+++ b/falcon_marshmallow/_version.py
@@ -12,5 +12,5 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-__version_info__ = (0, 2, 0)
+__version_info__ = (0, 3, 0)
 __version__ = '.'.join([str(ver) for ver in __version_info__])

--- a/falcon_marshmallow/middleware.py
+++ b/falcon_marshmallow/middleware.py
@@ -299,7 +299,16 @@ class Marshmallow:
                 raise HTTPBadRequest('Request must be valid JSON')
 
             try:
-                data = sch.load(parsed)
+                data_ = sch.load(parsed)
+                # marshmallow 2.x backwards compatibility
+                if isinstance(data_, tuple):
+                    data, errors = data_
+                    if errors:
+                        raise HTTPUnprocessableEntity(
+                            description = self._json.dumps(errors)
+                        )
+                else:
+                    data = data_
             except ValidationError as e:
                 raise HTTPUnprocessableEntity(
                     description=self._json.dumps(e.messages)
@@ -362,7 +371,17 @@ class Marshmallow:
                 )
 
             try:
-                data = sch.dumps(req.context[self._resp_key])
+                data_ = sch.dumps(req.context[self._resp_key])
+                # marshmallow 2.x backwards compatibility
+                if isinstance(data_, tuple):
+                    data, errors = data_
+                    if errors:
+                        raise HTTPInternalServerError(
+                            title = 'Could not serialize response',
+                            description = json.dumps(errors)
+                        )
+                else:
+                    data = data_
             except ValidationError as e:
                 raise HTTPInternalServerError(
                     title='Could not serialize response',


### PR DESCRIPTION
I needed to use some new features in the upcoming Marshmallow 3.x release (on RC4 at the moment) and the response of the the (de)serialization methods doesn't return a tuple of the data and errors anymore. (See the discussion [here](https://github.com/marshmallow-code/marshmallow/issues/598).) This is the only broken thing I have come across so far, and I'm using the falcon-marshmallow library pretty heavily.